### PR TITLE
Setup release on CI when tag is pushed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - v*
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install wasm-pack
+      run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+    # remove scope or update it once we decide exactly where we want to deploy this thing
+    - run: wasm-pack build --target nodejs
+    - run: npm publish
+      working-directory: pkg

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing
+
+## Prerequisites
+
+- You need to have rustup installed, and when you run `cargo build` or `cargo test` it will use the nightly rust version that is defined in `rust-toolchain` in the root of the repo.
+- You need to run `rustup target add wasm32-unknown-unknown` to download this target for your system
+- You need to install wasm-pack https://rustwasm.github.io/wasm-pack/
+
+## Running
+
+CLI:
+
+`cargo run ./sample/component.gjs`
+
+Tests:
+
+`cargo test`:
+
+Build wasm package:
+
+`wasm-pack build --target=nodejs`
+
+which will output your wasm package in `./pkg`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,8 @@
 [package]
 name = "content-tag"
+description = "A rust program that uses a fork of swc to parse GJS and transpile to valid JS"
+repository = "https://github.com/embroider-build/content-tag"
+license = "MIT"
 version = "0.1.0"
 edition = "2021"
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Edward Faulkner
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,30 +1,26 @@
 # content-tag
 
-## Prerequisites
+`content-tag` is a preprocessor for JS files that are using the content-tag proposal. This originated with Ember.js' GJS and GTS functionality. You can read more by [checking out the original RFC](https://rfcs.emberjs.com/id/0931-template-compiler-api/)
 
-- rust nightly via rustup (at time of writing I'm using rustc 1.71.0-nightly (f5559e338 2023-04-24))
-- wasm-pack
-- rustup target add wasm32-unknown-unknown
-- you need to clone ef4/swc `content-tag` branch and have it located next to your clone of this repo
+This preprocessor can be used to transform files using the `content-tag` spec to standard JS. It is built on top of [swc](https://swc.rs/) using Rust and is deployed as a wasm package.
 
-## Running
-
-CLI:
-
-`cargo run ./sample/component.gjs`
-
-Tests:
-
-`cargo test`:
-
-Build wasm package:
-
-`wasm-pack build --target=nodejs --scope=ef4`
-
-See wasm package in action:
+## Installation
 
 ```sh
-let { Preprocessor } = require('./pkg');
-let p = new Preprocessor();
-p.process('<template>Hi</template>');
+# note this will change when we decide where this package lives
+npm install @real_ate/content-tag
 ```
+
+## Usage
+
+```js
+let { Preprocessor } = require('content-tag');
+let p = new Preprocessor();
+let output = p.process('<template>Hi</template>');
+console.log(output);
+```
+
+## Contributing
+
+See the [CONTRIBUTING.md](./CONTRIBUTING.md) file.
+


### PR DESCRIPTION
This PR also adds a few things that are nice for the release i.e. updating the readme to be about the consumers of the package and moving build instructions to a contributing.md file 👍 