### PR TITLE
Enable typescript

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ use swc_ecma_ast::{
     ModuleItem,
 };
 use swc_ecma_codegen::Emitter;
-use swc_ecma_parser::{lexer::Lexer, EsConfig, Parser, StringInput, Syntax};
+use swc_ecma_parser::{lexer::Lexer, TsConfig, Parser, StringInput, Syntax};
 use swc_ecma_transforms::hygiene::hygiene_with_config;
 use swc_ecma_transforms::resolver;
 use swc_ecma_utils::private_ident;
@@ -56,7 +56,7 @@ impl Preprocessor {
             .new_source_file(filename, src.to_string());
 
         let lexer = Lexer::new(
-            Syntax::Es(EsConfig {
+            Syntax::Typescript(TsConfig {
                 decorators: true,
                 ..Default::default()
             }),
@@ -275,3 +275,17 @@ testcase! {
          return template1("X", { eval() { return eval(arguments[0])} });
        };"#
 }
+
+
+testcase! {
+    handles_typescript,
+    r#"function makeComponent(message: string) {
+        console.log(message);
+        return <template>hello</template>
+    }"#,
+    r#"import { template } from "@ember/template-compiler";
+       function makeComponent(message: string) {
+         console.log(message);
+         return template("hello", { eval() { return eval(arguments[0]) } });
+       }"#
+  }

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -2,7 +2,7 @@ use difference::Changeset;
 use swc_common::comments::SingleThreadedComments;
 use swc_common::{self, sync::Lrc, FileName, SourceMap};
 use swc_ecma_codegen::Emitter;
-use swc_ecma_parser::{lexer::Lexer, EsConfig, Parser, StringInput, Syntax};
+use swc_ecma_parser::{lexer::Lexer, TsConfig, Parser, StringInput, Syntax};
 
 use crate::Preprocessor;
 
@@ -28,7 +28,7 @@ fn normalize(src: &str) -> String {
     let source_file = source_map.new_source_file(FileName::Real(filename), src.to_string());
 
     let lexer = Lexer::new(
-        Syntax::Es(EsConfig {
+        Syntax::Typescript(TsConfig {
             decorators: true,
             ..Default::default()
         }),


### PR DESCRIPTION
This enables typescript syntax.

As far as I can tell, there's no downside to keeping it enabled all the time, since it is a superset of javascript syntax, and we're only doing parsing & serialization, not any transforms.