### PR TITLE
Fix: Inner expressions get missed

### DIFF
--- a/src/transform.rs
+++ b/src/transform.rs
@@ -153,3 +153,14 @@ test!(
     r#"<template>Hello</template>"#,
     r#"export default template("Hello", { eval() { return eval(arguments[0]) }},);"#
 );
+
+test!(
+    Default::default(),
+    |_| as_folder(TransformVisitor::new(
+        &Ident::new("template".into(), Default::default()),
+        None,
+    )),
+    inner_expression,
+    r#"let x = doIt(<template>Hello</template>)"#,
+    r#"let x = doIt(template("Hello", { eval() { return eval(arguments[0]) }}))"#
+);

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -45,6 +45,7 @@ impl<'a> TransformVisitor<'a> {
 
 impl<'a> VisitMut for TransformVisitor<'a> {
     fn visit_mut_expr(&mut self, n: &mut Expr) {
+        n.visit_mut_children_with(self);
         if let Expr::ContentTagExpression(expr) = n {
             *n = self.transform_tag_expression(expr);
             self.set_found_it();
@@ -52,6 +53,7 @@ impl<'a> VisitMut for TransformVisitor<'a> {
     }
 
     fn visit_mut_class_member(&mut self, n: &mut ClassMember) {
+        n.visit_mut_children_with(self);
         if let ClassMember::ContentTagMember(ContentTagMember { span, contents }) = n {
             let content_literal = Box::new(Expr::Lit(Lit::Str(contents.clone().into()))).into();
 
@@ -141,6 +143,34 @@ test!(
           template("Hello", { component: this, eval() { return eval(arguments[0]) }},);
       }
   }"#
+);
+
+test!(
+    Default::default(),
+    |_| as_folder(TransformVisitor::new(
+        &Ident::new("template".into(), Default::default()),
+        None,
+    )),
+    expression_inside_class_member,
+    r#"class X { thing = <template>Hello</template> } "#,
+    r#"class X {
+        thing = template("Hello", { eval() { return eval(arguments[0]) }},);
+    }"#
+);
+
+test!(
+    Default::default(),
+    |_| as_folder(TransformVisitor::new(
+        &Ident::new("template".into(), Default::default()),
+        None,
+    )),
+    class_member_inside_expression,
+    r#"let x = class { <template>Hello</template> } "#,
+    r#"let x = class {
+        static {
+            template("Hello", { component: this, eval() { return eval(arguments[0]) }},);
+        }
+    }"#
 );
 
 test!(


### PR DESCRIPTION
We need to explicitly recurse in our transform handlers in order to make sure our transform applies in deeper parts of the AST.