### PR TITLE
Initial sourcemapping support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,13 +88,13 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 [[package]]
 name = "ast_node"
 version = "0.9.5"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "pmutil",
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn 2.0.29",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -148,9 +148,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "base64"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
+
+[[package]]
 name = "better_scoped_tls"
 version = "0.1.1"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "scoped-tls",
 ]
@@ -256,15 +262,14 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.28"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ed24df0632f708f5f6d8082675bef2596f7084dee3dd55f632290bf35bfe0f"
+checksum = "defd4e7873dbddba6c7c91e199c7fcb946abc4a6a4ac3195400bcfb01b5de877"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
- "time 0.1.45",
  "wasm-bindgen",
  "windows-targets",
 ]
@@ -273,6 +278,7 @@ dependencies = [
 name = "content-tag"
 version = "1.0.1"
 dependencies = [
+ "base64 0.21.4",
  "difference",
  "js-sys",
  "lazy_static",
@@ -437,7 +443,7 @@ checksum = "eecf8589574ce9b895052fa12d69af7a233f99e6107f5cb8dd1044f2a17bfdcb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -491,12 +497,12 @@ dependencies = [
 [[package]]
 name = "from_variant"
 version = "0.1.6"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "pmutil",
  "proc-macro2",
  "swc_macros_common",
- "syn 2.0.29",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -518,7 +524,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -658,7 +664,7 @@ dependencies = [
  "pmutil",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -708,15 +714,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.5"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
+checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
 
 [[package]]
 name = "lock_api"
@@ -754,9 +760,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.6.2"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5486aed0026218e61b8a01d5fbd5a0a134649abb71a0e53b7bc088529dced86e"
+checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
 name = "memoffset"
@@ -891,9 +897,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ac5bbd07aea88c60a577a1ce218075ffd59208b2d7ca97adf9bfc5aeb21ebe"
+checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
 dependencies = [
  "memchr",
 ]
@@ -1025,7 +1031,7 @@ checksum = "52a40bc70c2c58040d2d8b167ba9a5ff59fc9dab7ad44771cfde3dcfde7a09c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -1043,7 +1049,7 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 [[package]]
 name = "preset_env_base"
 version = "0.4.5"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1099,9 +1105,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
 dependencies = [
  "unicode-ident",
 ]
@@ -1193,13 +1199,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.4"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12de2eff854e5fa4b1295edd650e227e9d8fb0c9e90b12e7f36d6a6811791a29"
+checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.7",
+ "regex-automata 0.3.8",
  "regex-syntax 0.7.5",
 ]
 
@@ -1214,9 +1220,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49530408a136e16e5b486e883fbb6ba058e8e4e8ae6621a77b048b314336e629"
+checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1264,9 +1270,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.10"
+version = "0.38.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6248e1caa625eb708e266e06159f135e8c26f2bb7ceb72dc4b2766d0340964"
+checksum = "d7db8590df6dfcd144d22afd1b83b36c21a18d7cbc1dc4bb5295a8712e9eb662"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
@@ -1357,14 +1363,14 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.33",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.105"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
+checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
  "itoa",
  "ryu",
@@ -1474,7 +1480,7 @@ dependencies = [
  "pmutil",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -1512,13 +1518,13 @@ dependencies = [
 [[package]]
 name = "string_enum"
 version = "0.4.1"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "pmutil",
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn 2.0.29",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -1552,10 +1558,10 @@ dependencies = [
 [[package]]
 name = "swc"
 version = "0.265.7"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.13.1",
  "dashmap",
  "either",
  "indexmap 1.9.3",
@@ -1598,7 +1604,7 @@ dependencies = [
 [[package]]
 name = "swc_atoms"
 version = "0.5.9"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "once_cell",
  "rustc-hash",
@@ -1611,7 +1617,7 @@ dependencies = [
 [[package]]
 name = "swc_cached"
 version = "0.3.17"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1624,7 +1630,7 @@ dependencies = [
 [[package]]
 name = "swc_common"
 version = "0.32.0"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "ahash",
  "ast_node",
@@ -1654,7 +1660,7 @@ dependencies = [
 [[package]]
 name = "swc_config"
 version = "0.1.7"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "indexmap 1.9.3",
  "serde",
@@ -1665,19 +1671,19 @@ dependencies = [
 [[package]]
 name = "swc_config_macro"
 version = "0.1.2"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "pmutil",
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn 2.0.29",
+ "syn 2.0.33",
 ]
 
 [[package]]
 name = "swc_core"
 version = "0.82.7"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -1691,7 +1697,7 @@ dependencies = [
 [[package]]
 name = "swc_ecma_ast"
 version = "0.109.0"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "bitflags 2.4.0",
  "is-macro",
@@ -1707,7 +1713,7 @@ dependencies = [
 [[package]]
 name = "swc_ecma_codegen"
 version = "0.144.1"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -1725,19 +1731,19 @@ dependencies = [
 [[package]]
 name = "swc_ecma_codegen_macros"
 version = "0.7.3"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "pmutil",
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn 2.0.29",
+ "syn 2.0.33",
 ]
 
 [[package]]
 name = "swc_ecma_ext_transforms"
 version = "0.108.0"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "phf",
  "swc_atoms",
@@ -1750,7 +1756,7 @@ dependencies = [
 [[package]]
 name = "swc_ecma_lints"
 version = "0.87.2"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "auto_impl",
  "dashmap",
@@ -1769,7 +1775,7 @@ dependencies = [
 [[package]]
 name = "swc_ecma_loader"
 version = "0.44.2"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -1789,7 +1795,7 @@ dependencies = [
 [[package]]
 name = "swc_ecma_minifier"
 version = "0.186.5"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "arrayvec",
  "indexmap 1.9.3",
@@ -1822,7 +1828,7 @@ dependencies = [
 [[package]]
 name = "swc_ecma_parser"
 version = "0.139.0"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "either",
  "num-bigint",
@@ -1841,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "swc_ecma_preset_env"
 version = "0.200.4"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -1865,7 +1871,7 @@ dependencies = [
 [[package]]
 name = "swc_ecma_testing"
 version = "0.21.0"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "anyhow",
  "hex",
@@ -1877,7 +1883,7 @@ dependencies = [
 [[package]]
 name = "swc_ecma_transforms"
 version = "0.223.3"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -1896,7 +1902,7 @@ dependencies = [
 [[package]]
 name = "swc_ecma_transforms_base"
 version = "0.132.2"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.4.0",
@@ -1918,7 +1924,7 @@ dependencies = [
 [[package]]
 name = "swc_ecma_transforms_classes"
 version = "0.121.2"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -1931,7 +1937,7 @@ dependencies = [
 [[package]]
 name = "swc_ecma_transforms_compat"
 version = "0.158.3"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "arrayvec",
  "indexmap 1.9.3",
@@ -1955,19 +1961,19 @@ dependencies = [
 [[package]]
 name = "swc_ecma_transforms_macros"
 version = "0.5.3"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "pmutil",
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn 2.0.29",
+ "syn 2.0.33",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_module"
 version = "0.175.3"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1993,7 +1999,7 @@ dependencies = [
 [[package]]
 name = "swc_ecma_transforms_optimization"
 version = "0.192.3"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "dashmap",
  "indexmap 1.9.3",
@@ -2016,7 +2022,7 @@ dependencies = [
 [[package]]
 name = "swc_ecma_transforms_proposal"
 version = "0.166.3"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "either",
  "rustc-hash",
@@ -2035,9 +2041,9 @@ dependencies = [
 [[package]]
 name = "swc_ecma_transforms_react"
 version = "0.178.3"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "dashmap",
  "indexmap 1.9.3",
  "once_cell",
@@ -2058,11 +2064,11 @@ dependencies = [
 [[package]]
 name = "swc_ecma_transforms_testing"
 version = "0.135.2"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "ansi_term",
  "anyhow",
- "base64",
+ "base64 0.13.1",
  "hex",
  "serde",
  "serde_json",
@@ -2083,7 +2089,7 @@ dependencies = [
 [[package]]
 name = "swc_ecma_transforms_typescript"
 version = "0.182.3"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -2098,7 +2104,7 @@ dependencies = [
 [[package]]
 name = "swc_ecma_usage_analyzer"
 version = "0.18.1"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "indexmap 1.9.3",
  "rustc-hash",
@@ -2114,7 +2120,7 @@ dependencies = [
 [[package]]
 name = "swc_ecma_utils"
 version = "0.122.0"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "indexmap 1.9.3",
  "num_cpus",
@@ -2131,7 +2137,7 @@ dependencies = [
 [[package]]
 name = "swc_ecma_visit"
 version = "0.95.0"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -2144,18 +2150,18 @@ dependencies = [
 [[package]]
 name = "swc_eq_ignore_macros"
 version = "0.1.2"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "pmutil",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.33",
 ]
 
 [[package]]
 name = "swc_error_reporters"
 version = "0.16.0"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "anyhow",
  "miette",
@@ -2167,7 +2173,7 @@ dependencies = [
 [[package]]
 name = "swc_fast_graph"
 version = "0.20.0"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "indexmap 1.9.3",
  "petgraph",
@@ -2178,18 +2184,18 @@ dependencies = [
 [[package]]
 name = "swc_macros_common"
 version = "0.3.8"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "pmutil",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.33",
 ]
 
 [[package]]
 name = "swc_node_comments"
 version = "0.19.0"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "dashmap",
  "swc_atoms",
@@ -2199,7 +2205,7 @@ dependencies = [
 [[package]]
 name = "swc_timer"
 version = "0.20.0"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "tracing",
 ]
@@ -2207,17 +2213,17 @@ dependencies = [
 [[package]]
 name = "swc_trace_macro"
 version = "0.1.3"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.33",
 ]
 
 [[package]]
 name = "swc_visit"
 version = "0.5.7"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "either",
  "swc_visit_macros",
@@ -2226,14 +2232,14 @@ dependencies = [
 [[package]]
 name = "swc_visit_macros"
 version = "0.5.8"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "Inflector",
  "pmutil",
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn 2.0.29",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -2249,9 +2255,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.29"
+version = "2.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
+checksum = "9caece70c63bfba29ec2fed841a09851b14a235c60010fa4de58089b6c025668"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2293,7 +2299,7 @@ dependencies = [
 [[package]]
 name = "testing"
 version = "0.34.0"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "ansi_term",
  "cargo_metadata",
@@ -2312,7 +2318,7 @@ dependencies = [
 [[package]]
 name = "testing_macros"
 version = "0.2.11"
-source = "git+https://github.com/ef4/swc.git?branch=content-tag#e74f7b3a09a97597937241d9d170f3401c0e3a18"
+source = "git+https://github.com/ef4/swc.git?branch=content-tag#0a1132a5c9abed0d21d8471076abf5c3bfd33ba4"
 dependencies = [
  "anyhow",
  "glob",
@@ -2322,7 +2328,7 @@ dependencies = [
  "quote",
  "regex",
  "relative-path",
- "syn 2.0.29",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -2338,22 +2344,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.47"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
+checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.47"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
+checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -2364,17 +2370,6 @@ checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if",
  "once_cell",
-]
-
-[[package]]
-name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
 ]
 
 [[package]]
@@ -2440,7 +2435,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -2512,15 +2507,15 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-id"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d70b6494226b36008c8366c288d77190b3fad2eb4c10533139c1c1f461127f1a"
+checksum = "b1b6def86329695390197b82c1e244a54a131ceb66c996f2088a3876e2ae083f"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-linebreak"
@@ -2578,7 +2573,7 @@ dependencies = [
  "getset",
  "rustversion",
  "thiserror",
- "time 0.3.28",
+ "time",
 ]
 
 [[package]]
@@ -2586,12 +2581,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -2620,7 +2609,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.33",
  "wasm-bindgen-shared",
 ]
 
@@ -2642,7 +2631,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.33",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ swc_ecma_utils = { git = "https://github.com/ef4/swc.git", branch = "content-tag
 swc_ecma_transforms = { git = "https://github.com/ef4/swc.git", branch = "content-tag" }
 swc_error_reporters = { git = "https://github.com/ef4/swc.git", branch = "content-tag" }
 lazy_static = "1.4.0"
-
+base64 = "0.21.4"
 wasm-bindgen = "0.2.63"
 js-sys = "0.3.64"
 

--- a/sample/component.gjs
+++ b/sample/component.gjs
@@ -1,10 +1,10 @@
-import { template as t } from '@ember/template-compiler';
-
-console.log(template
-
-const Inner = <template>I am inner</template>
+const Inner = <template>I am inner {{yield}}</template>
 
 // here's a comment
 export class Outer {
-  <template><Inner /></template>
+  <template>
+    <Inner>
+      Hello world
+    </Inner>
+  </template>
 }

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -1,10 +1,9 @@
 use crate::{Options, Preprocessor as CorePreprocessor};
-use std::{fmt,  str};
+use std::{fmt, str};
 use swc_common::{
     errors::Handler,
     sync::{Lock, Lrc},
-    SourceMap,
-    Spanned,
+    SourceMap, Spanned,
 };
 use swc_error_reporters::{GraphicalReportHandler, GraphicalTheme, PrettyEmitter};
 use wasm_bindgen::prelude::*;
@@ -29,7 +28,11 @@ impl fmt::Write for Writer {
     }
 }
 
-fn capture_err_detail(err: swc_ecma_parser::error::Error, source_map: Lrc<SourceMap>, theme: GraphicalTheme) -> JsValue {
+fn capture_err_detail(
+    err: swc_ecma_parser::error::Error,
+    source_map: Lrc<SourceMap>,
+    theme: GraphicalTheme,
+) -> JsValue {
     let wr = Writer::default();
     let emitter = PrettyEmitter::new(
         source_map,
@@ -46,8 +49,22 @@ fn capture_err_detail(err: swc_ecma_parser::error::Error, source_map: Lrc<Source
 fn as_javascript_error(err: swc_ecma_parser::error::Error, source_map: Lrc<SourceMap>) -> JsValue {
     let short_desc = format!("Parse Error at {}", source_map.span_to_string(err.span()));
     let js_err = js_error(short_desc.into());
-    js_sys::Reflect::set(&js_err, &"source_code".into(), &capture_err_detail(err.clone(), source_map.clone(), GraphicalTheme::unicode_nocolor())).unwrap();
-    js_sys::Reflect::set(&js_err, &"source_code_color".into(), &capture_err_detail(err, source_map, GraphicalTheme::unicode())).unwrap();
+    js_sys::Reflect::set(
+        &js_err,
+        &"source_code".into(),
+        &capture_err_detail(
+            err.clone(),
+            source_map.clone(),
+            GraphicalTheme::unicode_nocolor(),
+        ),
+    )
+    .unwrap();
+    js_sys::Reflect::set(
+        &js_err,
+        &"source_code_color".into(),
+        &capture_err_detail(err, source_map, GraphicalTheme::unicode()),
+    )
+    .unwrap();
     return js_err;
 }
 
@@ -64,8 +81,8 @@ impl Preprocessor {
         let result = self.core.process(
             &src,
             Options {
-                filename: filename.map(|f| f.into())
-            }
+                filename: filename.map(|f| f.into()),
+            },
         );
 
         match result {

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -82,7 +82,7 @@ impl Preprocessor {
             &src,
             Options {
                 filename: filename.map(|f| f.into()),
-                inlineSourcemap: false,
+                inline_source_map: false,
             },
         );
 

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -82,6 +82,7 @@ impl Preprocessor {
             &src,
             Options {
                 filename: filename.map(|f| f.into()),
+                inlineSourcemap: false,
             },
         );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ mod transform;
 #[derive(Default)]
 pub struct Options {
     pub filename: Option<PathBuf>,
-    pub inlineSourcemap: bool,
+    pub inline_source_map: bool,
 }
 
 pub struct Preprocessor {
@@ -110,7 +110,7 @@ impl Preprocessor {
 
             simplify_imports(&mut parsed_module);
 
-            Ok(self.print(&parsed_module, options.inlineSourcemap))
+            Ok(self.print(&parsed_module, options.inline_source_map))
         })
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ fn main() {
         &src,
         Options {
             filename: Some(filename),
-            inlineSourcemap: true,
+            inline_source_map: true,
         },
     );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ fn main() {
         &src,
         Options {
             filename: Some(filename),
+            inlineSourcemap: true,
         },
     );
 

--- a/src/snippets.rs
+++ b/src/snippets.rs
@@ -1,19 +1,20 @@
 use swc_common::comments::SingleThreadedComments;
+use swc_common::Span;
 use swc_common::{self, sync::Lrc, FileName, SourceMap};
-use swc_ecma_ast::Expr;
+use swc_ecma_ast::{Expr, Module};
 use swc_ecma_parser::{lexer::Lexer, EsConfig, Parser, StringInput, Syntax};
+use swc_ecma_visit::{as_folder, VisitMut, VisitMutWith};
 
 lazy_static! {
-    pub static ref SCOPE_PARAMS: Box<Expr> =
-        parse_expression(r#"({ eval() { return eval(arguments[0]); } })"#);
+    static ref SCOPE_PARAMS: Module = parse(r#"({ eval() { return eval(arguments[0]); } })"#);
 }
 
 lazy_static! {
-    pub static ref SCOPE_PARAMS_WITH_THIS: Box<Expr> =
-        parse_expression(r#"({ component: this, eval() { return eval(arguments[0]); } })"#);
+    static ref SCOPE_PARAMS_WITH_THIS: Module =
+        parse(r#"({ component: this, eval() { return eval(arguments[0]); } })"#);
 }
 
-fn parse_expression(src: &str) -> Box<Expr> {
+fn parse(src: &str) -> Module {
     let filename = "glimmer-template-prelude.js".into();
     let source_map: Lrc<SourceMap> = Default::default();
     let comments = SingleThreadedComments::default();
@@ -31,8 +32,21 @@ fn parse_expression(src: &str) -> Box<Expr> {
     );
 
     let mut parser = Parser::new_from(lexer);
-    let module = parser.parse_module().unwrap();
+    parser.parse_module().unwrap()
+}
 
+struct SpanReplacer {
+    span: Span,
+}
+impl VisitMut for SpanReplacer {
+    fn visit_mut_span(&mut self, n: &mut Span) {
+        *n = self.span;
+    }
+}
+
+fn generate_expression(span: Span, template_module: &Module) -> Box<Expr> {
+    let mut module = template_module.clone();
+    module.visit_mut_with(&mut as_folder(SpanReplacer { span }));
     module
         .body
         .first()
@@ -46,4 +60,12 @@ fn parse_expression(src: &str) -> Box<Expr> {
         .unwrap()
         .expr
         .clone()
+}
+
+pub fn scope_params(span: Span) -> Box<Expr> {
+    generate_expression(span, &(*SCOPE_PARAMS))
+}
+
+pub fn scope_params_with_this(span: Span) -> Box<Expr> {
+    generate_expression(span, &(*SCOPE_PARAMS_WITH_THIS))
 }

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -1,14 +1,16 @@
 use swc_core::ecma::{
     ast::{
         BlockStmt, CallExpr, Callee, ClassMember, ContentTagExpression, ContentTagMember, Expr,
-        ExprStmt, Ident, Lit, StaticBlock, Stmt,
+        ExprStmt, Ident, StaticBlock, Stmt,
     },
     transforms::testing::test,
     visit::VisitMut,
     visit::VisitMutWith,
 };
 
-use swc_ecma_ast::{ExportDefaultExpr, ModuleDecl, ModuleItem};
+use swc_ecma_ast::{
+    ContentTagContent, ExportDefaultExpr, ExprOrSpread, ModuleDecl, ModuleItem, Tpl, TplElement,
+};
 
 pub struct TransformVisitor<'a> {
     template_identifier: Ident,
@@ -29,17 +31,36 @@ impl<'a> TransformVisitor<'a> {
         }
     }
     fn transform_tag_expression(&mut self, expr: &ContentTagExpression) -> Expr {
-        let ContentTagExpression { span, contents } = expr;
-        let content_literal = Box::new(Expr::Lit(Lit::Str(contents.clone().into()))).into();
+        let ContentTagExpression {
+            span,
+            contents,
+            closing,
+            ..
+        } = expr;
+
         Expr::Call(CallExpr {
             span: *span,
             callee: Callee::Expr(Box::new(Expr::Ident(self.template_identifier.clone()))),
             args: vec![
-                content_literal,
-                crate::snippets::SCOPE_PARAMS.clone().into(),
+                self.content_literal(contents),
+                crate::snippets::scope_params(closing.span).into(),
             ],
             type_args: None,
         })
+    }
+
+    fn content_literal(&self, contents: &Box<ContentTagContent>) -> ExprOrSpread {
+        Box::new(Expr::Tpl(Tpl {
+            span: contents.span,
+            exprs: vec![],
+            quasis: vec![TplElement {
+                span: contents.span,
+                cooked: None,
+                raw: contents.value.clone().into(),
+                tail: false,
+            }],
+        }))
+        .into()
     }
 }
 
@@ -54,15 +75,19 @@ impl<'a> VisitMut for TransformVisitor<'a> {
 
     fn visit_mut_class_member(&mut self, n: &mut ClassMember) {
         n.visit_mut_children_with(self);
-        if let ClassMember::ContentTagMember(ContentTagMember { span, contents }) = n {
-            let content_literal = Box::new(Expr::Lit(Lit::Str(contents.clone().into()))).into();
-
+        if let ClassMember::ContentTagMember(ContentTagMember {
+            span,
+            opening,
+            contents,
+            closing,
+        }) = n
+        {
             let call_expr = Expr::Call(CallExpr {
                 span: *span,
                 callee: Callee::Expr(Box::new(Expr::Ident(self.template_identifier.clone()))),
                 args: vec![
-                    content_literal,
-                    crate::snippets::SCOPE_PARAMS_WITH_THIS.clone().into(),
+                    self.content_literal(contents),
+                    crate::snippets::scope_params_with_this(closing.span).into(),
                 ],
                 type_args: None,
             });
@@ -71,7 +96,7 @@ impl<'a> VisitMut for TransformVisitor<'a> {
                 expr: Box::new(call_expr),
             };
             *n = ClassMember::StaticBlock(StaticBlock {
-                span: *span,
+                span: opening.span,
                 body: BlockStmt {
                     span: *span,
                     stmts: vec![Stmt::Expr(call_statement)],
@@ -84,8 +109,7 @@ impl<'a> VisitMut for TransformVisitor<'a> {
     fn visit_mut_module_items(&mut self, items: &mut Vec<ModuleItem>) {
         let mut items_updated = Vec::with_capacity(items.len());
         for item in items.drain(..) {
-            if let Some(content_tag) = content_tag_expression_statement(&item) 
-            {
+            if let Some(content_tag) = content_tag_expression_statement(&item) {
                 items_updated.push(ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultExpr(
                     ExportDefaultExpr {
                         span: content_tag.span,
@@ -107,7 +131,8 @@ fn content_tag_expression_statement(item: &ModuleItem) -> Option<&ContentTagExpr
     if let ModuleItem::Stmt(Stmt::Expr(ExprStmt {
         expr: box Expr::ContentTagExpression(content_tag),
         ..
-    })) = item {
+    })) = item
+    {
         Some(content_tag)
     } else {
         None

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -152,7 +152,7 @@ test!(
     },
     content_tag_template_expression,
     r#"let x = <template>Hello</template>"#,
-    r#"let x = template("Hello", { eval() { return eval(arguments[0]); }})"#
+    r#"let x = template(`Hello`, { eval() { return eval(arguments[0]); }})"#
 );
 
 test!(
@@ -165,7 +165,7 @@ test!(
     r#"class X { <template>Hello</template> } "#,
     r#"class X {
       static {
-          template("Hello", { component: this, eval() { return eval(arguments[0]) }},);
+          template(`Hello`, { component: this, eval() { return eval(arguments[0]) }},);
       }
   }"#
 );
@@ -179,7 +179,7 @@ test!(
     expression_inside_class_member,
     r#"class X { thing = <template>Hello</template> } "#,
     r#"class X {
-        thing = template("Hello", { eval() { return eval(arguments[0]) }},);
+        thing = template(`Hello`, { eval() { return eval(arguments[0]) }},);
     }"#
 );
 
@@ -193,7 +193,7 @@ test!(
     r#"let x = class { <template>Hello</template> } "#,
     r#"let x = class {
         static {
-            template("Hello", { component: this, eval() { return eval(arguments[0]) }},);
+            template(`Hello`, { component: this, eval() { return eval(arguments[0]) }},);
         }
     }"#
 );
@@ -206,7 +206,7 @@ test!(
     )),
     content_tag_export_default,
     r#"<template>Hello</template>"#,
-    r#"export default template("Hello", { eval() { return eval(arguments[0]) }},);"#
+    r#"export default template(`Hello`, { eval() { return eval(arguments[0]) }},);"#
 );
 
 test!(
@@ -217,5 +217,5 @@ test!(
     )),
     inner_expression,
     r#"let x = doIt(<template>Hello</template>)"#,
-    r#"let x = doIt(template("Hello", { eval() { return eval(arguments[0]) }}))"#
+    r#"let x = doIt(template(`Hello`, { eval() { return eval(arguments[0]) }}))"#
 );

--- a/test/node-api.js
+++ b/test/node-api.js
@@ -1,57 +1,65 @@
-const { Preprocessor } = require('../pkg');
-const chai = require('chai');
+const { Preprocessor } = require("../pkg");
+const chai = require("chai");
 const { codeEquality } = require("code-equality-assertions/chai");
 
-chai.use(codeEquality)
+chai.use(codeEquality);
 
 const { expect } = chai;
 
 const p = new Preprocessor();
 
-describe("something", function() {
-  it("works for a basic example", function() {
-    let output = p.process('<template>Hi</template>');
+describe("something", function () {
+  it("works for a basic example", function () {
+    let output = p.process("<template>Hi</template>");
 
-    expect(output).to.equalCode(`import { template } from "@ember/template-compiler";
-    export default template("Hi", {
+    expect(output).to
+      .equalCode(`import { template } from "@ember/template-compiler";
+    export default template(\`Hi\`, {
         eval () {
             return eval(arguments[0]);
         }
     });`);
   });
 
-  it("Emits parse errors with anonymous file", function() {
-    expect(function() {
+  it("Emits parse errors with anonymous file", function () {
+    expect(function () {
       p.process(`const thing = "face";
   <template>Hi`);
     }).to.throw(`Parse Error at <anon>:2:15: 2:15`);
   });
 
-  it("Emits parse errors with real file", function() {
-    expect(function() {
-      p.process(`const thing = "face";
-  <template>Hi`, "path/to/my/component.gjs");
+  it("Emits parse errors with real file", function () {
+    expect(function () {
+      p.process(
+        `const thing = "face";
+  <template>Hi`,
+        "path/to/my/component.gjs"
+      );
     }).to.throw(`Parse Error at path/to/my/component.gjs:2:15: 2:15`);
   });
 
-  it("Offers source_code snippet on parse errors", function() {
+  it("Offers source_code snippet on parse errors", function () {
     let parseError;
     try {
-      p.process(`class {`)
+      p.process(`class {`);
     } catch (err) {
       parseError = err;
     }
-    expect(parseError).to.have.property("source_code").matches(/Expected ident.*class \{/s);
+    expect(parseError)
+      .to.have.property("source_code")
+      .matches(/Expected ident.*class \{/s);
   });
 
-  it("Offers source_code_color snippet on parse errors", function() {
+  it("Offers source_code_color snippet on parse errors", function () {
     let parseError;
     try {
-      p.process(`class {`)
+      p.process(`class {`);
     } catch (err) {
       parseError = err;
     }
     // eslint-disable-next-line no-control-regex
-    expect(parseError).to.have.property("source_code_color").matches(/Expected ident.*[\u001b].*class \{/s);
+    expect(parseError)
+      .to.have.property("source_code_color")
+      .matches(/Expected ident.*[\u001b].*class \{/s);
   });
-})
+});


### PR DESCRIPTION
This ensures that our transport is emitting good spans.

The rust-layer library now includes an option to append inline source maps, just because that was a straightforward way for me to test how our span-handling is working. It's not exposed to the JS bindings at this time.