### PR TITLE
Transform callback

### DIFF
--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -1,4 +1,4 @@
-use crate::{Options, Preprocessor as CorePreprocessor};
+use crate::Preprocessor as CorePreprocessor;
 use std::{fmt, str};
 use swc_common::{
     errors::Handler,
@@ -81,20 +81,14 @@ impl Preprocessor {
     pub fn new() -> Self {
         // TODO: investigate reuse
         // Self {
-        //     core: Box::new(CorePreprocessor::new()),
+        //     core: Box::new(CorePreprocessor::new(Default::default())),
         // }
         Self {}
     }
 
     pub fn process(&self, src: String, filename: Option<String>) -> Result<String, JsValue> {
-        let preprocessor = CorePreprocessor::new();
-        let result = preprocessor.process(
-            &src,
-            Options {
-                filename: filename.map(|f| f.into()),
-                inline_source_map: false,
-            },
-        );
+        let preprocessor = CorePreprocessor::new(Default::default());
+        let result = preprocessor.process(&src, filename.map(|f| f.into()));
 
         match result {
             Ok(output) => Ok(output),
@@ -103,15 +97,9 @@ impl Preprocessor {
     }
 
     pub fn parse(&self, src: String, filename: Option<String>) -> Result<JsValue, JsValue> {
-        let preprocessor = CorePreprocessor::new();
+        let preprocessor = CorePreprocessor::new(Default::default());
         let result = preprocessor
-            .parse(
-                &src,
-                Options {
-                    filename: filename.as_ref().map(|f| f.into()),
-                    inline_source_map: false,
-                },
-            )
+            .parse(&src, filename.as_ref().map(|f| f.into()))
             .map_err(|_err| self.process(src, filename).unwrap_err())?;
         let serialized = serde_json::to_string(&result)
             .map_err(|err| js_error(format!("Unexpected serialization error; please open an issue with the following debug info: {err:#?}").into()))?;

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -33,7 +33,7 @@ extern "C" {
 
 #[wasm_bindgen]
 pub struct Preprocessor {
-    options: Options    
+    options: Lrc<Options>    
 }
 
 #[derive(Clone, Default)]
@@ -85,9 +85,9 @@ fn as_javascript_error(err: swc_ecma_parser::error::Error, source_map: Lrc<Sourc
     return js_err;
 }
 
-impl Into<Options> for JsOptions {
-    fn into(self) -> Options {
-        Options { inline_source_map: self.inline_source_map() }
+impl Into<Lrc<Options>> for JsOptions {
+    fn into(self) -> Lrc<Options> {
+        Lrc::new(Options { inline_source_map: self.inline_source_map() })
     }
 }
 
@@ -104,7 +104,7 @@ impl Preprocessor {
     }
 
     pub fn process(&self, src: String, filename: Option<String>) -> Result<String, JsValue> {
-        let preprocessor = CorePreprocessor::new(self.options);
+        let preprocessor = CorePreprocessor::new(self.options.clone());
         let result = preprocessor.process(&src, filename.map(|f| f.into()));
 
         match result {
@@ -114,7 +114,7 @@ impl Preprocessor {
     }
 
     pub fn parse(&self, src: String, filename: Option<String>) -> Result<JsValue, JsValue> {
-        let preprocessor = CorePreprocessor::new(self.options);
+        let preprocessor = CorePreprocessor::new(self.options.clone());
         let result = preprocessor
             .parse(&src, filename.as_ref().map(|f| f.into()))
             .map_err(|_err| self.process(src, filename).unwrap_err())?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ mod snippets;
 mod transform;
 mod locate;
 
-#[derive(Default)]
+#[derive(Default, Clone, Copy)]
 pub struct Options {
     pub inline_source_map: bool,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ mod locate;
 #[derive(Default)]
 pub struct Options {
     pub inline_source_map: bool,
+    pub transformer: Option<Box<dyn Fn(String) -> String>>
 }
 
 pub struct Preprocessor {
@@ -124,6 +125,7 @@ impl Preprocessor {
             parsed_module.visit_mut_with(&mut as_folder(transform::TransformVisitor::new(
                 &id,
                 Some(&mut needs_import),
+                self.options.clone()
             )));
 
             if !had_id_already && needs_import {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,13 +27,13 @@ mod locate;
 
 #[derive(Default)]
 pub struct Options {
-    pub filename: Option<PathBuf>,
     pub inline_source_map: bool,
 }
 
 pub struct Preprocessor {
     source_map: Lrc<SourceMap>,
     comments: SingleThreadedComments,
+    options: Options,
 }
 
 struct SourceMapConfig;
@@ -49,19 +49,20 @@ impl SourceMapGenConfig for SourceMapConfig {
 
 
 impl Preprocessor {
-    pub fn new() -> Self {
+    pub fn new(options: Options) -> Self {
         Self {
             source_map: Default::default(),
             comments: SingleThreadedComments::default(),
+            options
         }
     }
 
     pub fn parse(
         &self,
         src: &str,
-        options: Options,
+        filename: Option<PathBuf>,
     ) -> Result<Vec<locate::Occurrence>, swc_ecma_parser::error::Error> {
-        let filename = match options.filename {
+        let filename = match filename {
             Some(name) => FileName::Real(name),
             None => FileName::Anon,
         };
@@ -92,11 +93,11 @@ impl Preprocessor {
     pub fn process(
         &self,
         src: &str,
-        options: Options,
+        filename: Option<PathBuf>,
     ) -> Result<String, swc_ecma_parser::error::Error> {
         let target_specifier = "template";
         let target_module = "@ember/template-compiler";
-        let filename = match options.filename {
+        let filename = match filename {
             Some(name) => FileName::Real(name),
             None => FileName::Anon,
         };
@@ -144,7 +145,7 @@ impl Preprocessor {
 
             simplify_imports(&mut parsed_module);
 
-            Ok(self.print(&parsed_module, options.inline_source_map))
+            Ok(self.print(&parsed_module, self.options.inline_source_map))
         })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ mod snippets;
 mod transform;
 mod locate;
 
-#[derive(Default, Clone, Copy)]
+#[derive(Default)]
 pub struct Options {
     pub inline_source_map: bool,
 }
@@ -33,7 +33,7 @@ pub struct Options {
 pub struct Preprocessor {
     source_map: Lrc<SourceMap>,
     comments: SingleThreadedComments,
-    options: Options,
+    options: Lrc<Options>,
 }
 
 struct SourceMapConfig;
@@ -49,7 +49,7 @@ impl SourceMapGenConfig for SourceMapConfig {
 
 
 impl Preprocessor {
-    pub fn new(options: Options) -> Self {
+    pub fn new(options: Lrc<Options>) -> Self {
         Self {
             source_map: Default::default(),
             comments: SingleThreadedComments::default(),

--- a/src/locate.rs
+++ b/src/locate.rs
@@ -123,7 +123,7 @@ use crate::Preprocessor;
 
 #[test]
 fn test_basic_example() {
-    let p = Preprocessor::new();
+    let p = Preprocessor::new(Default::default());
     let output = p
         .parse("<template>Hello!</template>", Default::default())
         .unwrap();
@@ -141,7 +141,7 @@ fn test_basic_example() {
 
 #[test]
 fn test_expression_position() {
-    let p = Preprocessor::new();
+    let p = Preprocessor::new(Default::default());
     let output = p
         .parse(
             "const tpl = <template>Hello!</template>",
@@ -164,7 +164,7 @@ fn test_expression_position() {
 
 #[test]
 fn test_inside_class_body() {
-    let p = Preprocessor::new();
+    let p = Preprocessor::new(Default::default());
     let output = p
         .parse(
             r#"
@@ -191,7 +191,7 @@ fn test_inside_class_body() {
 
 #[test]
 fn test_preceded_by_a_slash_character() {
-    let p = Preprocessor::new();
+    let p = Preprocessor::new(Default::default());
     // What is this testing?
     // Would a better test be:
     // `const divide = 1 / <template>Hello!</template>;`
@@ -220,7 +220,7 @@ fn test_preceded_by_a_slash_character() {
 
 #[test]
 fn test_template_inside_a_regexp() {
-    let p = Preprocessor::new();
+    let p = Preprocessor::new(Default::default());
     let output = p
         .parse(
             r#"
@@ -246,7 +246,7 @@ fn test_template_inside_a_regexp() {
 
 #[test]
 fn test_no_match() {
-    let p = Preprocessor::new();
+    let p = Preprocessor::new(Default::default());
     let output = p
         .parse("console.log('Hello world');", Default::default())
         .unwrap();
@@ -256,7 +256,7 @@ fn test_no_match() {
 
 #[test]
 fn test_inner_expression() {
-    let p = Preprocessor::new();
+    let p = Preprocessor::new(Default::default());
     let src = r#"let x = doIt(<template>Hello</template>)"#;
     let output = p.parse(src, Default::default()).unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use std::env;
 use std::fs;
 use std::path::PathBuf;
 use std::process::exit;
+use std::sync::Arc;
 
 use swc_common::errors::{ColorConfig, Handler};
 
@@ -16,9 +17,9 @@ fn main() {
 
     let src = fs::read_to_string(filename.clone()).unwrap();
 
-    let p = Preprocessor::new(Options {
+    let p = Preprocessor::new(Arc::new(Options {
         inline_source_map: true,
-    });
+    }));
 
     let result = p.process(&src, Some(filename));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use content_tag::Preprocessor;
+use content_tag::{Options, Preprocessor};
 use std::env;
 use std::fs;
 use std::path::PathBuf;
@@ -16,7 +16,9 @@ fn main() {
 
     let src = fs::read_to_string(filename.clone()).unwrap();
 
-    let p = Preprocessor::new(Default::default());
+    let p = Preprocessor::new(Options {
+        inline_source_map: true,
+    });
 
     let result = p.process(&src, Some(filename));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ fn main() {
 
     let p = Preprocessor::new(Arc::new(Options {
         inline_source_map: true,
+        transformer: None,
     }));
 
     let result = p.process(&src, Some(filename));

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use content_tag::{Options, Preprocessor};
+use content_tag::Preprocessor;
 use std::env;
 use std::fs;
 use std::path::PathBuf;
@@ -16,15 +16,9 @@ fn main() {
 
     let src = fs::read_to_string(filename.clone()).unwrap();
 
-    let p = Preprocessor::new();
+    let p = Preprocessor::new(Default::default());
 
-    let result = p.process(
-        &src,
-        Options {
-            filename: Some(filename),
-            inline_source_map: true,
-        },
-    );
+    let result = p.process(&src, Some(filename));
 
     match result {
         Ok(output) => println!("{}", output),

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -7,7 +7,7 @@ use swc_ecma_parser::{lexer::Lexer, Parser, StringInput, Syntax, TsConfig};
 use crate::Preprocessor;
 
 pub fn testcase(input: &str, expected: &str) -> Result<(), swc_ecma_parser::error::Error> {
-    let p = Preprocessor::new();
+    let p = Preprocessor::new(Default::default());
     let actual = p.process(input, Default::default())?;
     let normalized_expected = normalize(expected);
     if actual != normalized_expected {

--- a/test/node-api.js
+++ b/test/node-api.js
@@ -262,4 +262,10 @@ describe("process", function () {
       .to.have.property("source_code_color")
       .matches(/Expected ident.*[\u001b].*class \{/s);
   });
+
+  it("can optionally include sourcemap", function () {
+    let p = new Preprocessor({ inline_source_map: true });
+    let output = p.process("<template>Hi</template>");
+    expect(output).to.contain('sourceMappingURL');
+  });
 });

--- a/test/node-api.js
+++ b/test/node-api.js
@@ -268,4 +268,17 @@ describe("process", function () {
     let output = p.process("<template>Hi</template>");
     expect(output).to.contain('sourceMappingURL');
   });
+
+  it("can invoke custom transformer", function () {
+    let p = new Preprocessor({ transformer: (s) => s + '!' });
+    let output = p.process("<template>Hi</template>");
+    expect(output).to.equalCode(`
+    import { template } from "@ember/template-compiler";
+    export default template(\`Hi!\`, {
+        eval () {
+            return eval(arguments[0]);
+        }
+    });
+    `)
+  });
 });


### PR DESCRIPTION
This adds an optional `transformer` callback that can rewrite the template contents.

At the moment this PR has a more limited API than I intend to land. I want the transformer callback to have control over the whole JS replacement expression (not just the string literal template contents), with a complete jsutils API that is drop-in compatible with the one in babel-plugin-ember-template-compilation.