### PR TITLE
Give the changelog a title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-
+# `content-tag` Changelog
 
 ## 1.1.2 (2023-10-06)
 


### PR DESCRIPTION
According to the error in https://github.com/embroider-build/content-tag/actions/runs/7188581742/job/19578501105

The changelog needs a title that ends in `Changelog`