### PR TITLE
npm pkg fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A rust program that uses a fork of swc to parse and transform Javascript containing the content-tag proposal",
   "repository": {
     "type": "git",
-    "url": "git@github.com:embroider-build/content-tag.git"
+    "url": "git+ssh://git@github.com/embroider-build/content-tag.git"
   },
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
In the logs for https://github.com/embroider-build/content-tag/actions/runs/7201384902/job/19617380808#step:5:9

it said:
```
npm WARN publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm WARN publish errors corrected:
npm WARN publish "repository.url" was normalized to "git+ssh://git@github.com/embroider-build/content-tag.git"
```

So this PR is the changes produced by `npm pkg fix`