### PR TITLE
Add .npmignore to not ignore pkg/* folders

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+/target
+/node_modules


### PR DESCRIPTION
Marking as `bug` because we have to publish over the 1.2.0 release because it's missing assets. 1.2.1 will have the built wasm files.

Problem revealed in https://github.com/embroider-build/content-tag/actions/runs/7201384902/job/19617380808#step:5:9 where the package is way too small, revealing wasm assets missing.


-------

According to `npm publish` docs: 
https://docs.npmjs.com/cli/v10/commands/npm-publish


> If there is a .gitignore or .npmignore file, then ignored files in that and all child directories will be excluded from the package. If both files exist, then the .gitignore is ignored, and only the .npmignore is used.


![image](https://github.com/embroider-build/content-tag/assets/199018/2da7daca-3068-4992-ae19-24ba8877712e)

So this PR adds an `.npmignore` that _doesn't_ ignore the `pkg/node` and `pkg/standalone` folders.

We have `pkg/node/` and `pkg/standalone/` in the .gitignore because all the files in these folders are generated, and wouldn't make sense to track in git.

<details><summary>Old analysis (which is now irrelevant) </summary>

History on this is super weird

Folks are saying that `ignore-scripts=true`
should affect npm publish...
and that... npm 9+ _does_ ignore all scripts,
rather than scripts-from-deps-you-install
https://github.com/npm/cli/issues/3707#issuecomment-1313573119

I don't agree with any of this, fwiw.

imo, ignore-scripts shouldn't be all scripts... like, your own lifecycle scripts should be included here.
I have a hunch unclear / reports-lacking-detail are partly to blame for broad confusion around how this is supposed to work :(

People are confusing prepare and prepack as well.

---------


_However_,
The docs still say that `prepack` should be running: https://docs.npmjs.com/cli/v10/using-npm/scripts

So... the investigation continues.

`pnpm pack`
- `prepack` runs
- `prepublishOnly` runs
`pnpm publish`
- `prepack` runs
- `prepublishOnly` runs, but it's too late, as the `tgz` has already been created, and is still missing the wasm files

`npm pack`
- `prepack` does NOT run
`npm publish`
- `prepack` does NOT run
- `prepublishOnly` runs, but it's too late, as the `tgz` has already been created, and is still missing the wasm files


NOTE: this repo uses `npm`

</details>