### PR TITLE
Remove extraneous gitignores which interfere with packing

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -12,3 +12,6 @@ wasm-pack build --target nodejs --out-dir pkg/node --weak-refs --no-pack --relea
 
 # Rename the node js file to cjs, because we emit type=module
 mv pkg/node/content_tag.js pkg/node/content_tag.cjs
+
+rm pkg/node/.gitignore
+rm pkg/standalone/.gitignore

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
       },
       "import": {
         "types": "./index.d.ts",
+        "import": "./pkg/standalone.js",
         "default": "./pkg/node/content_tag.cjs"
       },
       "require": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
       },
       "import": {
         "types": "./index.d.ts",
-        "import": "./pkg/standalone.js",
         "default": "./pkg/node/content_tag.cjs"
       },
       "require": {
@@ -37,7 +36,7 @@
     "ci:node": "mocha",
     "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
     "lint:package": "publint",
-    "lint:published-types": "attw --pack --ignore-rules cjs-resolves-to-esm",
+    "lint:published-types": "attw --pack --ignore-rules cjs-resolves-to-esm --ignore-rules false-esm",
     "start": "vite",
     "test": "npm run ci:node"
   },


### PR DESCRIPTION
I've learned some things..

A difference between `npm` and `pnpm`.

`pnpm` (correct): runs lifecycle scripts on your own package regardless of your `ignore-scripts=true` in your `.npmrc`.

`npm` (incorrect): ignores all lifecycle scripts when `ignore-scripts=true` is present, including the obvious ones that you wrote yourself (as you'd define prepack in your own library to help with publishing). 

`ignore-scripts=true` was meant for _dependencies_ not your own package.... 


## Locally

If you don't have `ignore-scirpts=true`:

```
npm pack
```

If you do have `ignore-scripts=true`:

```bash
npm run prepack
npm pack
```

_before this change_,
the built tgz is missing the pkg/node and pkg/standalone folders.

_after this change_,
the built tgz includes the pkg/node and pkg/standalone folders.