### PR TITLE
Reproduce issue described in #45 - multi-byte characters are counted incorrectly.

### DIFF
--- a/test/node-api.cjs
+++ b/test/node-api.cjs
@@ -37,6 +37,37 @@ describe("parse", function () {
     ]);
   });
 
+  it("multi-byte characters", function () {
+    let contentLength = "안녕하세요 세계".length;
+    let openLength = "<template>".length;
+    let closeLength = "</template>".length;
+    let output = p.parse("<template>안녕하세요 세계</template>");
+
+    expect(output).to.eql([
+      {
+        type: "expression",
+        tagName: "template",
+        contents: "안녕하세요 세계",
+        range: {
+          start: 0,
+          end: openLength + contentLength + closeLength,
+        },
+        contentRange: {
+          start: openLength,
+          end: openLength + contentLength,
+        },
+        startRange: {
+          end: openLength,
+          start: 0,
+        },
+        endRange: {
+          start: openLength + contentLength - 1,
+          end: openLength + contentLength + closeLength,
+        },
+      },
+    ]);
+  });
+
   it("expression position", function () {
     let output = p.parse("const tpl = <template>Hello!</template>");
 


### PR DESCRIPTION
Multi-byte characters are counted incorrectly.

_or_

Rust and JS count string length differently :upside_down_face: 

(at which point, our JS offset output is a bit misleading, because we don't exactly communicate that the ranges are byte offsets, and it's not super straight forward to convert from byte offsets to char offsets in JS)