### PR TITLE
Add js/rust bindings for inline source map generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,6 +283,7 @@ dependencies = [
  "js-sys",
  "lazy_static",
  "serde",
+ "serde-wasm-bindgen",
  "serde_json",
  "swc",
  "swc_atoms",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ lazy_static = "1.4.0"
 base64 = "0.21.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde-wasm-bindgen = "0.4"
 
 wasm-bindgen = "0.2.63"
 js-sys = "0.3.64"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "content-tag",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "content-tag",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
       "import": {
         "types": "./index.d.ts",
         "browser": "./pkg/standalone.js",
-        "default": "./pkg/node/content_tag.cjs"
+        "default": "./pkg/node.cjs"
       },
       "require": {
         "types": "./index.d.ts",
-        "default": "./pkg/node/content_tag.cjs"
+        "default": "./pkg/node.cjs"
       }
     }
   },

--- a/pkg/node.cjs
+++ b/pkg/node.cjs
@@ -1,14 +1,11 @@
-import init from "./node/content_tag.js";
-import { Preprocessor as WasmPreprocessor } from "./standalone/content_tag.js";
-
-await init();
+const { Preprocessor: WasmPreprocessor } = require("./node/content_tag.cjs");
 
 const defaultOptions = {
   inline_source_map: false,
   filename: null
 };
 
-export class Preprocessor {
+class Preprocessor {
   #preprocessor;
 
   constructor() {
@@ -23,3 +20,5 @@ export class Preprocessor {
     return this.#preprocessor.parse(str, { ...defaultOptions, ...options });
   }
 }
+
+module.exports.Preprocessor = Preprocessor;

--- a/pkg/standalone.js
+++ b/pkg/standalone.js
@@ -1,4 +1,4 @@
-import init from "./node/content_tag.js";
+import init from "./standalone/content_tag.js";
 import { Preprocessor as WasmPreprocessor } from "./standalone/content_tag.js";
 
 await init();

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -86,13 +86,13 @@ impl Preprocessor {
         Self {}
     }
 
-    pub fn process(&self, src: String, filename: Option<String>) -> Result<String, JsValue> {
+    pub fn process(&self, src: String, filename: Option<String>, inline_source_map: bool) -> Result<String, JsValue> {
         let preprocessor = CorePreprocessor::new();
         let result = preprocessor.process(
             &src,
             Options {
                 filename: filename.map(|f| f.into()),
-                inline_source_map: false,
+                inline_source_map,
             },
         );
 
@@ -112,7 +112,7 @@ impl Preprocessor {
                     inline_source_map: false,
                 },
             )
-            .map_err(|_err| self.process(src, filename).unwrap_err())?;
+            .map_err(|_err| self.process(src, filename, false).unwrap_err())?;
         let serialized = serde_json::to_string(&result)
             .map_err(|err| js_error(format!("Unexpected serialization error; please open an issue with the following debug info: {err:#?}").into()))?;
         Ok(json_parse(serialized.into()))

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -173,7 +173,7 @@ describe(`parse`, function () {
       p.process(
         `const thing = "face";
   <template>Hi`,
-        "path/to/my/component.gjs",
+        { filename: 'path/to/my/component.gjs' }
       );
     }).to.throw(`Parse Error at path/to/my/component.gjs:2:15: 2:15`);
   });

--- a/test/process.test.js
+++ b/test/process.test.js
@@ -44,7 +44,7 @@ describe(`process`, function () {
                  }
              });
          }
-     };`,
+     };`
     );
   });
 
@@ -60,7 +60,7 @@ describe(`process`, function () {
       p.process(
         `const thing = "face";
   <template>Hi`,
-        "path/to/my/component.gjs",
+        { filename: "path/to/my/component.gjs" }
       );
     }).to.throw(`Parse Error at path/to/my/component.gjs:2:15: 2:15`);
   });
@@ -88,5 +88,19 @@ describe(`process`, function () {
     expect(parseError)
       .to.have.property("source_code_color")
       .matches(/Expected ident.*[\u001b].*class \{/s);
+  });
+
+  it("Provides inline source maps if inline_source_map option is set to true", function () {
+    let output = p.process(`<template>Hi</template>`, { inline_source_map: true });
+
+    expect(output).to.equalCode(
+      `import { template } from "@ember/template-compiler";
+      export default template(\`Hi\`, {
+          eval () {
+              return eval(arguments[0]);
+          }
+      });
+      //# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIjxhbm9uPiJdLCJzb3VyY2VzQ29udGVudCI6WyI8dGVtcGxhdGU-SGk8L3RlbXBsYXRlPiJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiO0FBQUEsZUFBQSxTQUFVLENBQUEsRUFBRSxDQUFBLEVBQUE7SUFBQTtRQUFBLE9BQUEsS0FBQSxTQUFBLENBQUEsRUFBVztJQUFEO0FBQUEsR0FBQyJ9`
+    );
   });
 });


### PR DESCRIPTION
Fixes https://github.com/embroider-build/content-tag/issues/61

Right now I just added an extra argument to make it a non-braking change, but if you feel like we want to have second argument be an object that accepts the `filename: string` and `input_source_maps: bool`I can also change it to that