### PR TITLE
Update type declaration file with latest API

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -26,6 +26,14 @@ interface Parsed {
   };
 }
 
+interface PreprocessorOptions {
+
+  /** Default is `false` */
+  inline_source_map?: boolean;
+
+  filename?: string;
+
+}
 
 /**
 */
@@ -36,14 +44,14 @@ export class Preprocessor {
   constructor();
 /**
 * @param {string} src
-* @param {string | undefined} filename
+* @param {PreprocessorOptions | undefined} options
 * @returns {string}
 */
-  process(src: string, filename?: string): string;
+  process(src: string, options?: PreprocessorOptions): string;
 /**
 * @param {string} src
-* @param {string | undefined} filename
+* @param {PreprocessorOptions | undefined} options
 * @returns {any}
 */
-  parse(src: string, filename?: string): Parsed[];
+  parse(src: string, options?: PreprocessorOptions): Parsed[];
 }


### PR DESCRIPTION
I missed that there is a type declarations file....
Only noticed once I tried to bump `content-tag` in other packages that ts was failing in those