### PR TITLE
Fix sourcemap test

### DIFF
--- a/test/process.test.js
+++ b/test/process.test.js
@@ -93,14 +93,8 @@ describe(`process`, function () {
   it("Provides inline source maps if inline_source_map option is set to true", function () {
     let output = p.process(`<template>Hi</template>`, { inline_source_map: true });
 
-    expect(output).to.equalCode(
-      `import { template } from "@ember/template-compiler";
-      export default template(\`Hi\`, {
-          eval () {
-              return eval(arguments[0]);
-          }
-      });
-      //# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIjxhbm9uPiJdLCJzb3VyY2VzQ29udGVudCI6WyI8dGVtcGxhdGU-SGk8L3RlbXBsYXRlPiJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiO0FBQUEsZUFBQSxTQUFVLENBQUEsRUFBRSxDQUFBLEVBQUE7SUFBQTtRQUFBLE9BQUEsS0FBQSxTQUFBLENBQUEsRUFBVztJQUFEO0FBQUEsR0FBQyJ9`
+    expect(output).to.match(
+      /sourceMappingURL=data:application\/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIjxhbm9uPiJdLCJzb3VyY2VzQ29udGVudCI6WyI8dGVtcGxhdGU-SGk8L3RlbXBsYXRlPiJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiO0FBQUEsZUFBQSxTQUFVLENBQUEsRUFBRSxDQUFBLEVBQUE7SUFBQTtRQUFBLE9BQUEsS0FBQSxTQUFBLENBQUEsRUFBVztJQUFEO0FBQUEsR0FBQyJ9/
     );
   });
 });


### PR DESCRIPTION
This test wasn't really detecting the sourcemap comment because `equalCode` ignores comments.