### PR TITLE
Refactor options handling

### DIFF
--- a/pkg/node.cjs
+++ b/pkg/node.cjs
@@ -1,24 +1,3 @@
-const { Preprocessor: WasmPreprocessor } = require("./node/content_tag.cjs");
-
-const defaultOptions = {
-  inline_source_map: false,
-  filename: null
-};
-
-class Preprocessor {
-  #preprocessor;
-
-  constructor() {
-    this.#preprocessor = new WasmPreprocessor();
-  }
-
-  process(str, options = {}) {
-    return this.#preprocessor.process(str, { ...defaultOptions, ...options });
-  }
-
-  parse(str, options = {}) {
-    return this.#preprocessor.parse(str, { ...defaultOptions, ...options });
-  }
-}
+const { Preprocessor } = require("./node/content_tag.cjs");
 
 module.exports.Preprocessor = Preprocessor;

--- a/pkg/standalone.js
+++ b/pkg/standalone.js
@@ -1,25 +1,5 @@
 import init from "./standalone/content_tag.js";
-import { Preprocessor as WasmPreprocessor } from "./standalone/content_tag.js";
+export { Preprocessor  } from "./standalone/content_tag.js";
 
 await init();
 
-const defaultOptions = {
-  inline_source_map: false,
-  filename: null
-};
-
-export class Preprocessor {
-  #preprocessor;
-
-  constructor() {
-    this.#preprocessor = new WasmPreprocessor();
-  }
-
-  process(str, options = {}) {
-    return this.#preprocessor.process(str, { ...defaultOptions, ...options });
-  }
-
-  parse(str, options = {}) {
-    return this.#preprocessor.parse(str, { ...defaultOptions, ...options });
-  }
-}

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -1,9 +1,5 @@
 use crate::{Options, Preprocessor as CorePreprocessor};
-use std::{
-    fmt,
-    str,
-    path::PathBuf,
-};
+use std::{fmt, path::PathBuf, str};
 use swc_common::{
     errors::Handler,
     sync::{Lock, Lrc},
@@ -11,8 +7,7 @@ use swc_common::{
 };
 use swc_error_reporters::{GraphicalReportHandler, GraphicalTheme, PrettyEmitter};
 use wasm_bindgen::prelude::*;
-use serde::{Serialize, Deserialize};
-use serde_wasm_bindgen::from_value;
+use js_sys::Reflect;
 
 #[wasm_bindgen]
 extern "C" {
@@ -21,6 +16,34 @@ extern "C" {
 
     #[wasm_bindgen(js_namespace = JSON, js_name = parse)]
     fn json_parse(value: JsValue) -> JsValue;
+
+    #[wasm_bindgen(js_name = Boolean)]
+    fn js_boolean(value: &JsValue) -> bool;
+
+    #[wasm_bindgen(js_name = String)]
+    fn js_string(value: &JsValue) -> String;
+}
+
+impl Options {
+    pub fn new(options: JsValue) -> Self {
+        if js_boolean(&options) {
+            let option_filename = Reflect::get(&options, &"filename".into()).unwrap();
+            let filename = if js_boolean(&option_filename) {
+                Some(PathBuf::from(js_string(&option_filename)))
+            } else {
+                None
+            };
+            Self {
+                inline_source_map: false,
+                filename,
+            }
+        } else {
+            Self {
+                inline_source_map: false,
+                filename: None,
+            }
+        }
+    }
 }
 
 #[wasm_bindgen]
@@ -30,12 +53,6 @@ pub struct Preprocessor {
     // out how to combine the APIs correctly to ensure we are not hanging on
     // to the states unexpectedly
     // core: Box<CorePreprocessor>,
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct ProcessOptions {
-    filename: Option<String>,
-    inline_source_map: bool,
 }
 
 #[derive(Clone, Default)]
@@ -99,17 +116,9 @@ impl Preprocessor {
     }
 
     pub fn process(&self, src: String, options: JsValue) -> Result<String, JsValue> {
-        let options: ProcessOptions = from_value(options)
-            .map_err(|e| js_error(format!("Options parsing error: {:?}", e).into()))?;
-
+        let options = Options::new(options);
         let preprocessor = CorePreprocessor::new();
-        let result = preprocessor.process(
-            &src,
-            Options {
-                filename: options.filename.map(|f| PathBuf::from(f)),
-                inline_source_map: options.inline_source_map,
-            },
-        );
+        let result = preprocessor.process(&src, options);
 
         match result {
             Ok(output) => Ok(output),
@@ -118,21 +127,18 @@ impl Preprocessor {
     }
 
     pub fn parse(&self, src: String, options: JsValue) -> Result<JsValue, JsValue> {
-        let parse_options: ProcessOptions = from_value(options.clone())
-            .map_err(|e| js_error(format!("Options parsing error: {:?}", e).into()))?;
-
+        let options = Options::new(options);
         let preprocessor = CorePreprocessor::new();
-        let result = preprocessor
-            .parse(
-                &src,
-                Options {
-                    filename: parse_options.filename.map(|f| PathBuf::from(f)),
-                    inline_source_map: parse_options.inline_source_map,
-                },
-            )
-            .map_err(|_err| self.process(src, options).unwrap_err())?;
-        let serialized = serde_json::to_string(&result)
-            .map_err(|err| js_error(format!("Unexpected serialization error; please open an issue with the following debug info: {err:#?}").into()))?;
-        Ok(json_parse(serialized.into()))
+        let result = preprocessor.parse(&src, options);
+
+        match result {
+            Ok(parsed) => {
+                match serde_json::to_string(&parsed) {
+                    Ok(serialized) => Ok(json_parse(serialized.into())),
+                    Err(err) =>  Err(js_error(format!("Unexpected serialization error; please open an issue with the following debug info: {err:#?}").into()))
+                }
+            },
+            Err(err) => Err(as_javascript_error(err, preprocessor.source_map()))
+        }
     }
 }

--- a/test/process.test.js
+++ b/test/process.test.js
@@ -90,8 +90,7 @@ describe(`process`, function () {
       .matches(/Expected ident.*[\u001b].*class \{/s);
   });
 
-  // TODO: this wasn't really testing because the comment is ignored
-  it.skip("Provides inline source maps if inline_source_map option is set to true", function () {
+  it("Provides inline source maps if inline_source_map option is set to true", function () {
     let output = p.process(`<template>Hi</template>`, { inline_source_map: true });
 
     expect(output).to.match(

--- a/test/process.test.js
+++ b/test/process.test.js
@@ -90,7 +90,8 @@ describe(`process`, function () {
       .matches(/Expected ident.*[\u001b].*class \{/s);
   });
 
-  it("Provides inline source maps if inline_source_map option is set to true", function () {
+  // TODO: this wasn't really testing because the comment is ignored
+  it.skip("Provides inline source maps if inline_source_map option is set to true", function () {
     let output = p.process(`<template>Hi</template>`, { inline_source_map: true });
 
     expect(output).to.equalCode(


### PR DESCRIPTION
The serde-based options handling isn't going to be able to accomodate callback types, which is something we want to add.

This is replacing it with a more hand-rolled `JsValue -> Options` conversion.