### PR TITLE
failing test case for typescript auto-export-default

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,3 +361,19 @@ testcase! {
          return template(`hello`, { eval() { return eval(arguments[0]) } });
        }"#
 }
+
+testcase! {
+  automatic_export_default,
+  r#"<template>Hello world</template>"#,
+  r#"import { template } from "@ember/template-compiler";
+      export default template(`Hello world`, { eval() { return eval(arguments[0]) } });
+   "#
+}
+
+testcase! {
+  automatic_export_default_typescript,
+  r#"<template>Hello world</template> satisfies MyType"#,
+  r#"import { template } from "@ember/template-compiler";
+      export default template(`Hello world`, { eval() { return eval(arguments[0]) } }) satisfies MyType;
+   "#
+}


### PR DESCRIPTION
Our automatic `export default` for a top-level `<template></template>` doesn't work if you're using typescript and append a `satisfies ...` to the template tag expression.