### PR TITLE
Strip hygiene code in favor of UUIDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,6 +283,7 @@ dependencies = [
  "difference",
  "js-sys",
  "lazy_static",
+ "regex",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
@@ -297,6 +298,7 @@ dependencies = [
  "swc_ecma_utils",
  "swc_ecma_visit",
  "swc_error_reporters",
+ "uuid",
  "wasm-bindgen",
 ]
 
@@ -1207,14 +1209,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.6"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebee201405406dbf528b8b672104ae6d6d63e6d118cb10e4d51abbc7b58044ff"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.9",
- "regex-syntax 0.7.5",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -1228,13 +1230,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.9"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b23e92ee4318893fa3fe3e6fb365258efbfe6ac6ab30f090cdcbb7aa37efa9"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.5",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -1245,9 +1247,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.5"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "relative-path"
@@ -2585,9 +2587,13 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.4.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
+checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+dependencies = [
+ "getrandom",
+ "rand",
+]
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,16 @@ serde-wasm-bindgen = "0.4"
 wasm-bindgen = "0.2.95"
 js-sys = "0.3.64"
 
+[dependencies.uuid]
+version = "1.11.0"
+features = [
+    "v4",       # Lets you generate random UUIDs
+    "fast-rng"  # Use a faster (but still sufficiently random) RNG
+]
+
 [dev-dependencies]
 difference = "2"
+regex = "1.11.1"
 
 
 

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -1,4 +1,5 @@
 use difference::Changeset;
+use regex::Regex;
 use swc_common::comments::SingleThreadedComments;
 use swc_common::{self, sync::Lrc, FileName, SourceMap};
 use swc_ecma_codegen::Emitter;
@@ -7,13 +8,15 @@ use swc_ecma_parser::{lexer::Lexer, Parser, StringInput, Syntax, TsConfig};
 use crate::Preprocessor;
 
 pub fn testcase(input: &str, expected: &str) -> Result<(), swc_ecma_parser::error::Error> {
+    let re = Regex::new(r"template_[0-9a-f]{32}").unwrap();
     let p = Preprocessor::new();
     let actual = p.process(input, Default::default())?;
+    let actual_santized = re.replace_all(&actual, "template_UUID");
     let normalized_expected = normalize(expected);
-    if actual != normalized_expected {
+    if actual_santized != normalized_expected {
         panic!(
             "code differs from expected:\n{}",
-            format!("{}", Changeset::new(&actual, &normalized_expected, "\n"))
+            format!("{}", Changeset::new(&actual_santized, &normalized_expected, "\n"))
         );
     }
     Ok(())

--- a/test/process.test.js
+++ b/test/process.test.js
@@ -8,13 +8,17 @@ const { expect } = chai;
 
 const p = new Preprocessor();
 
+function normalizeOutput(output) {
+  return output.replace(/template_[0-9a-f]{32}/g, "template_UUID");
+}
+
 describe(`process`, function () {
   it("works for a basic example", function () {
     let output = p.process("<template>Hi</template>");
 
-    expect(output).to
-      .equalCode(`import { template } from "@ember/template-compiler";
-  export default template(\`Hi\`, {
+    expect(normalizeOutput(output)).to
+      .equalCode(`import { template as template_UUID } from "@ember/template-compiler";
+  export default template_UUID(\`Hi\`, {
       eval () {
           return eval(arguments[0]);
       }
@@ -32,12 +36,12 @@ describe(`process`, function () {
 
     let output = p.process(input);
 
-    expect(output).to.equalCode(
-      `import { template } from "@ember/template-compiler";
-     let Foo = class Foo extends Component {
+    expect(normalizeOutput(output)).to.equalCode(
+      `import { template as template_UUID } from "@ember/template-compiler";
+     class Foo extends Component {
          greeting = 'Hello';
          static{
-             template(\`{{this.greeting}}, \\\`lifeform\\\`!\`, {
+             template_UUID(\`{{this.greeting}}, \\\`lifeform\\\`!\`, {
                  component: this,
                  eval () {
                      return eval(arguments[0]);
@@ -94,7 +98,7 @@ describe(`process`, function () {
     let output = p.process(`<template>Hi</template>`, { inline_source_map: true });
 
     expect(output).to.match(
-      /sourceMappingURL=data:application\/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIjxhbm9uPiJdLCJzb3VyY2VzQ29udGVudCI6WyI8dGVtcGxhdGU-SGk8L3RlbXBsYXRlPiJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiO0FBQUEsZUFBQSxTQUFVLENBQUEsRUFBRSxDQUFBLEVBQUE7SUFBQTtRQUFBLE9BQUEsS0FBQSxTQUFBLENBQUEsRUFBVztJQUFEO0FBQUEsR0FBQyJ9/
+      /sourceMappingURL=data:application\/json;base64,/
     );
   });
 });

--- a/test/require.test.cjs
+++ b/test/require.test.cjs
@@ -9,13 +9,17 @@ const { Preprocessor } = require("content-tag");
 
 const p = new Preprocessor();
 
+function normalizeOutput(output) {
+  return output.replace(/template_[0-9a-f]{32}/g, "template_UUID");
+}
+
 describe("cjs/require", function () {
   it("can call process", function () {
     let output = p.process("<template>Hi</template>");
 
-    expect(output).to
-      .equalCode(`import { template } from "@ember/template-compiler";
-  export default template(\`Hi\`, {
+    expect(normalizeOutput(output)).to
+      .equalCode(`import { template as template_UUID } from "@ember/template-compiler";
+  export default template_UUID(\`Hi\`, {
       eval () {
           return eval(arguments[0]);
       }


### PR DESCRIPTION
Fixes #71

After conversation with @wycats and reading @chancancode's comments in #71, it seems that our only concern here is making sure that the template import doesn't conflict. If we don't care about potentially importing multiple times (we can't see why we need to), then we can avoid the whole issue by always just importing it with a UUID.