### PR TITLE
Fix vite support

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,15 +10,13 @@
   "type": "module",
   "exports": {
     ".": {
-      "require": {
-        "node": {
-          "types": "./index.d.cts",
-          "default": "./pkg/node.cjs"
-        }
-      },
-      "default": {
+      "browser": {
         "types": "./index.d.ts",
         "default": "./pkg/standalone.js"
+      },
+      "node": {
+        "types": "./index.d.cts",
+        "default": "./pkg/node.cjs"
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -10,13 +10,15 @@
   "type": "module",
   "exports": {
     ".": {
-      "browser": {
-        "types": "./index.d.ts",
-        "default": "./pkg/standalone.js"
+      "require": {
+        "node": {
+          "types": "./index.d.cts",
+          "default": "./pkg/node.cjs"
+        }
       },
       "default": {
-        "types": "./index.d.cts",
-        "default": "./pkg/node.cjs"
+        "types": "./index.d.ts",
+        "default": "./pkg/standalone.js"
       }
     }
   },


### PR DESCRIPTION
Related to: https://discord.com/channels/804011606160703521/1303171812347215872/1303171812347215872

Under vite, through ember-repl -> content-tag, was getting this error:

```
`WebAssembly.instantiateStreaming` failed because your server does not serve wasm with `application/wasm` MIME type. 
  Falling back to `WebAssembly.instantiate` which is slower. 
  Original error:
     TypeError: 
        WebAssembly: 
          Response has unsupported MIME type 'text/html' 
          expected 'application/wasm' standalone-IQRAU4AM.js:252:19
Uncaught (in promise) wasm validation error: 
  at offset 4: failed to match magic number compiler.js:53:17
```

over here: https://github.com/universal-ember/kolay/pull/134

(making an actual type=module addon)

The code here is patched in to the above PR.

---------------

However, with changing `default` to `node`, we get a types error for the bundler check from are-the-types-wrong

<details><summary>exports</summary>

```
"exports": {
    ".": {
      "browser": {
        "types": "./index.d.ts",
        "default": "./pkg/standalone.js"
      },
      "node": {
        "types": "./index.d.cts",
        "default": "./pkg/node.cjs"
      }
    }
},
```

</details>

<details><summary>error</summary>

```

💀 Import failed to resolve to type declarations or JavaScript files. https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/NoResolution.md


┌───────────────────┬──────────────────────┐
│                   │ "content-tag"        │
├───────────────────┼──────────────────────┤
│ node10            │ 🟢                   │
├───────────────────┼──────────────────────┤
│ node16 (from CJS) │ 🟢 (CJS)             │
├───────────────────┼──────────────────────┤
│ node16 (from ESM) │ 🟢 (CJS)             │
├───────────────────┼──────────────────────┤
│ bundler           │ 💀 Resolution failed │
└───────────────────┴──────────────────────┘
Error: Process completed with exit code 1.
```

</details>

-------------------------

If I change it to use import and require for the top-level conditions this occurs

<details><summary>exports</summary>

```
  "exports": {
    ".": {
      "import": {
        "types": "./index.d.ts",
        "default": "./pkg/standalone.js"
      },
      "require": {
        "types": "./index.d.cts",
        "default": "./pkg/node.cjs"
      }
    }
  },
```

</details>
<details><summary>error</summary>

```
failed to load config from /home/nvp/Development/NullVoxPopuli/kolay/docs-app/vite.config.mjs
error when starting dev server:
TypeError: fetch failed
    at node:internal/deps/undici/undici:13392:13
    at async __wbg_init (file:///home/nvp/Development/NullVoxPopuli/kolay/node_modules/.pnpm/content-tag@2.0.2_patch_hash=36mmqi45qjbnwqjmwt7cs6ua5y/node_modules/content-tag/pkg/standalone/content_tag.js:504:51)
    at async file:///home/nvp/Development/NullVoxPopuli/kolay/node_modules/.pnpm/content-tag@2.0.2_patch_hash=36mmqi45qjbnwqjmwt7cs6ua5y/node_modules/content-tag/pkg/standalone.js:4:1
 ELIFECYCLE  Command failed with exit code 1.
 ELIFECYCLE  Command failed with exit code 1.
```

</details>