### PR TITLE
Change return type of process from string to { code, map }

### DIFF
--- a/index.d.cts
+++ b/index.d.cts
@@ -48,7 +48,7 @@ export class Preprocessor {
 * @param {PreprocessorOptions | undefined} options
 * @returns {string}
 */
-  process(src: string, options?: PreprocessorOptions): string;
+  process(src: string, options?: PreprocessorOptions): { code: string; map: string; };
 /**
 * @param {string} src
 * @param {PreprocessorOptions | undefined} options

--- a/index.d.ts
+++ b/index.d.ts
@@ -46,7 +46,7 @@ export class Preprocessor {
 * @param {PreprocessorOptions | undefined} options
 * @returns {string}
 */
-  process(src: string, options?: PreprocessorOptions): string;
+  process(src: string, options?: PreprocessorOptions): { code: string; map: string; };
 /**
 * @param {string} src
 * @param {PreprocessorOptions | undefined} options

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "content-tag",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "content-tag",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -1,5 +1,6 @@
-use crate::{Options, Preprocessor as CorePreprocessor};
+use crate::{CodeMapPair, Options, Preprocessor as CorePreprocessor};
 use js_sys::Reflect;
+use serde_wasm_bindgen::to_value;
 use std::{fmt, path::PathBuf, str};
 use swc_common::{
     errors::Handler,
@@ -123,13 +124,13 @@ impl Preprocessor {
         Self {}
     }
 
-    pub fn process(&self, src: String, options: JsValue) -> Result<String, JsValue> {
+    pub fn process(&self, src: String, options: JsValue) -> Result<CodeMapPair, JsValue> {
         let options = Options::new(options);
         let preprocessor = CorePreprocessor::new();
         let result = preprocessor.process(&src, options);
 
         match result {
-            Ok(output) => Ok(output),
+            Ok(output) => Ok(to_value(&output).unwrap()),
             Err(err) => Err(as_javascript_error(err, preprocessor.source_map()).into()),
         }
     }

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -1,4 +1,4 @@
-use crate::{CodeMapPair, Options, Preprocessor as CorePreprocessor};
+use crate::{Options, Preprocessor as CorePreprocessor};
 use js_sys::Reflect;
 use serde_wasm_bindgen::to_value;
 use std::{fmt, path::PathBuf, str};
@@ -52,6 +52,20 @@ impl Options {
                 filename: None,
             }
         }
+    }
+}
+
+#[wasm_bindgen]
+pub struct CodeMapPair {
+    pub code: String,
+    pub map: String,
+}
+
+#[wasm_bindgen]
+impl CodeMapPair {
+    #[wasm_bindgen(constructor)]
+    pub fn new(code: String, map: String) -> Self {
+        Self { code, map }
     }
 }
 
@@ -130,7 +144,7 @@ impl Preprocessor {
         let result = preprocessor.process(&src, options);
 
         match result {
-            Ok(output) => Ok(to_value(&output).unwrap()),
+            Ok(output) => Ok(CodeMapPair::new(output.code, output.map)),
             Err(err) => Err(as_javascript_error(err, preprocessor.source_map()).into()),
         }
     }

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -1,6 +1,5 @@
 use crate::{Options, Preprocessor as CorePreprocessor};
 use js_sys::Reflect;
-use serde_wasm_bindgen::to_value;
 use std::{fmt, path::PathBuf, str};
 use swc_common::{
     errors::Handler,
@@ -55,7 +54,7 @@ impl Options {
     }
 }
 
-#[wasm_bindgen]
+#[wasm_bindgen(getter_with_clone)]
 pub struct CodeMapPair {
     pub code: String,
     pub map: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ fn main() {
     );
 
     match result {
-        Ok(output) => println!("{}", output),
+        Ok(output) => println!("{}", output.code),
         Err(err) => {
             let handler =
                 Handler::with_tty_emitter(ColorConfig::Auto, true, false, Some(p.source_map()));

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -19,6 +19,9 @@ pub fn testcase(input: &str, expected: &str) -> Result<(), swc_ecma_parser::erro
             format!("{}", Changeset::new(&actual_santized, &normalized_expected, "\n"))
         );
     }
+
+    assert!(!actual.map.is_empty(), "expected .map to not be empty");
+
     Ok(())
 }
 

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -11,7 +11,7 @@ pub fn testcase(input: &str, expected: &str) -> Result<(), swc_ecma_parser::erro
     let re = Regex::new(r"template_[0-9a-f]{32}").unwrap();
     let p = Preprocessor::new();
     let actual = p.process(input, Default::default())?;
-    let actual_santized = re.replace_all(&actual, "template_UUID");
+    let actual_santized = re.replace_all(&actual.code, "template_UUID");
     let normalized_expected = normalize(expected);
     if actual_santized != normalized_expected {
         panic!(

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -173,7 +173,7 @@ describe(`parse`, function () {
       p.process(
         `const thing = "face";
   <template>Hi`,
-        { filename: 'path/to/my/component.gjs' }
+        { filename: "path/to/my/component.gjs" }
       );
     }).to.throw(`Parse Error at path/to/my/component.gjs:2:15: 2:15`);
   });

--- a/test/process.test.js
+++ b/test/process.test.js
@@ -16,7 +16,7 @@ describe(`process`, function () {
   it("works for a basic example", function () {
     let output = p.process("<template>Hi</template>");
 
-    expect(normalizeOutput(output)).to
+    expect(normalizeOutput(output.code)).to
       .equalCode(`import { template as template_UUID } from "@ember/template-compiler";
   export default template_UUID(\`Hi\`, {
       eval () {
@@ -36,7 +36,7 @@ describe(`process`, function () {
 
     let output = p.process(input);
 
-    expect(normalizeOutput(output)).to.equalCode(
+    expect(normalizeOutput(output.code)).to.equalCode(
       `import { template as template_UUID } from "@ember/template-compiler";
      class Foo extends Component {
          greeting = 'Hello';
@@ -97,7 +97,7 @@ describe(`process`, function () {
   it("Provides inline source maps if inline_source_map option is set to true", function () {
     let output = p.process(`<template>Hi</template>`, { inline_source_map: true });
 
-    expect(output).to.match(
+    expect(output.code).to.match(
       /sourceMappingURL=data:application\/json;base64,/
     );
   });

--- a/test/require.test.cjs
+++ b/test/require.test.cjs
@@ -17,7 +17,7 @@ describe("cjs/require", function () {
   it("can call process", function () {
     let output = p.process("<template>Hi</template>");
 
-    expect(normalizeOutput(output)).to
+    expect(normalizeOutput(output.code)).to
       .equalCode(`import { template as template_UUID } from "@ember/template-compiler";
   export default template_UUID(\`Hi\`, {
       eval () {


### PR DESCRIPTION
Goal: make it so `@embroider/addon-dev` doesn't need another dependency to correctly handle sourcemaps:

https://github.com/embroider-build/embroider/pull/2162


Tested here:
- https://github.com/embroider-build/embroider/pull/2166
  (success!)