### PR TITLE
Replace random import alias with constant

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,6 @@ use swc_ecma_parser::{lexer::Lexer, Parser, StringInput, Syntax, TsConfig};
 use swc_ecma_transforms::resolver;
 use swc_ecma_utils::private_ident;
 use swc_ecma_visit::{as_folder, VisitMutWith, VisitWith};
-use uuid::Uuid;
 
 mod bindings;
 mod locate;
@@ -40,6 +39,8 @@ pub struct CodeMapPair {
     pub code: String,
     pub map: String,
 }
+
+pub const IMPORT_ALIAS: &str = "template_fd9b2463e5f141cfb5666b64daa1f11a";
 
 struct SourceMapConfig;
 impl SourceMapGenConfig for SourceMapConfig {
@@ -120,11 +121,7 @@ impl Preprocessor {
         GLOBALS.set(&Default::default(), || {
             let mut parsed_module = parser.parse_module()?;
 
-            let id = private_ident!(format!(
-                "{}_{}",
-                target_specifier,
-                Uuid::new_v4().to_string().replace("-", "")
-            ));
+            let id = private_ident!(IMPORT_ALIAS);
             let mut needs_import = false;
             parsed_module.visit_mut_with(&mut as_folder(transform::TransformVisitor::new(
                 &id,

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -1,17 +1,16 @@
 use difference::Changeset;
-use regex::Regex;
 use swc_common::comments::SingleThreadedComments;
 use swc_common::{self, sync::Lrc, FileName, SourceMap};
 use swc_ecma_codegen::Emitter;
 use swc_ecma_parser::{lexer::Lexer, Parser, StringInput, Syntax, TsConfig};
 
 use crate::Preprocessor;
+use crate::IMPORT_ALIAS;
 
 pub fn testcase(input: &str, expected: &str) -> Result<(), swc_ecma_parser::error::Error> {
-    let re = Regex::new(r"template_[0-9a-f]{32}").unwrap();
     let p = Preprocessor::new();
     let actual = p.process(input, Default::default())?;
-    let actual_santized = re.replace_all(&actual.code, "template_UUID");
+    let actual_santized = actual.code.replace(IMPORT_ALIAS, "template_UUID");
     let normalized_expected = normalize(expected);
     if actual_santized != normalized_expected {
         panic!(


### PR DESCRIPTION
This will make content-tag builds reproducible, which is important to avoid unnecessary cache invalidation in production. The constant alias is sufficiently complex that it's extremely unlikely to clash with real user code.

Resolves #92