### PR TITLE
introduce a constructor in LocateContentTagVisitor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,11 +86,7 @@ impl Preprocessor {
         GLOBALS.set(&Default::default(), || {
             let parsed_module = parser.parse_module()?;
 
-            let mut visitor = locate::LocateContentTagVisitor {
-                occurrences: Default::default(),
-                is_ascii: src.is_ascii(),
-                src: src.to_string(),
-            };
+            let mut visitor = locate::LocateContentTagVisitor::new(src.to_string());
 
             parsed_module.visit_with(&mut visitor);
 

--- a/src/locate.rs
+++ b/src/locate.rs
@@ -9,8 +9,8 @@ use swc_ecma_visit::{Visit, VisitWith};
 #[derive(Default, Debug)]
 pub struct LocateContentTagVisitor {
     pub occurrences: Vec<Occurrence>,
-    pub src: String,
-    pub is_ascii: bool,
+    src: String,
+    is_ascii: bool,
 }
 
 #[derive(Eq, PartialEq, Debug, Serialize)]
@@ -21,6 +21,15 @@ enum ContentTagKind {
 }
 
 impl LocateContentTagVisitor {
+    pub fn new(src: String) -> Self {
+        let is_ascii = src.is_ascii();
+        Self {
+            occurrences: Default::default(),
+            src,
+            is_ascii,
+        }
+    }
+
     fn add_occurrence(
         &mut self,
         kind: ContentTagKind,


### PR DESCRIPTION
... to encapsulate the internals initialization that was leaking outside before.